### PR TITLE
ISSUE-1: Add default docker-compose.yml directly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,98 @@
+
+# Run docker-compose run -d
+# drush config-import
+# If running Linux, make sure /persistent/iiifcache has 100:100 ownership
+# If running Linux, make sure /persistent/solrcore has 8983:8983 ownership
+# enabling :cache for the volumens can bypass that need.
+# on OSX brew install minio/stable/mc for the minio client
+version: '3.5'
+services:
+  web:
+    container_name: esmero-web
+    restart: always
+    image: "nginx"
+    depends_on:
+      - solr
+      - php
+    tty: true
+    ports:
+      - "8001:80"
+    networks:
+      - host-net
+      - esmero-net
+    volumes:
+      - ${PWD}/nginxconfigford8/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ${PWD}:/var/www/html:cached
+  php:
+    container_name: esmero-php
+    restart: always
+    image: "esmero/php-7.3-fpm:8.x-1.0-beta1"
+    tty: true
+    networks:
+      - host-net
+      - esmero-net
+    volumes:
+      - ${PWD}:/var/www/html:cached
+  solr:
+    container_name: esmero-solr
+    restart: always
+    image: "solr:7.5.0"
+    tty: true
+    ports:
+      - "8983:8983"
+    networks:
+      - host-net
+      - esmero-net
+    volumes:
+      - ${PWD}/persistent/solrcore:/opt/solr/server/solr/mycores:cached
+      - ${PWD}/persistent/solrconfig:/drupalconfig:cached
+    entrypoint:
+      - docker-entrypoint.sh
+      - solr-precreate
+      - drupal
+      - /drupalconfig
+  # see https://hub.docker.com/_/mysql/
+  db:
+    image: mysql:5.7
+    container_name: esmero-db
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: esmerodb
+    networks:
+      - host-net
+      - esmero-net
+    volumes:
+      - ${PWD}/persistent/db:/var/lib/mysql:cached
+  iiif:
+    container_name: esmero-cantaloupe
+    image: "esmero/cantaloupe-s3:4.0.3"
+    restart: always
+    ports:
+      - "8183:8182"
+    networks:
+      - host-net
+      - esmero-net
+    volumes:
+      - ${PWD}/persistent/iiifconfig:/etc/cantaloupe
+      - ${PWD}/persistent/iiifcache:/var/cache/cantaloupe
+  minio:
+    container_name: esmero-minio
+    restart: always
+    image: minio/minio:latest
+    volumes:
+         - ${PWD}/persistent/miniodata:/data:cached
+    ports:
+         - "9000:9000"
+    networks:
+      - host-net
+      - esmero-net
+    environment:
+         MINIO_ACCESS_KEY: minio
+         MINIO_SECRET_KEY: minio123
+    command: server /data
+networks:
+  host-net:
+    driver: bridge
+  esmero-net:
+    driver: bridge
+    internal: true


### PR DESCRIPTION
We have this file in our .gitignore file to avoid overwriting people's local modifications when doing a git pull but also to avoid pushing local customizations. This should fix #1  without touching docs.