### PR TITLE
ISSUE-8: Create simple Archipelago Packages Update Script

### DIFF
--- a/scripts/archipelago/update.sh
+++ b/scripts/archipelago/update.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+echo -e "Updating Archipelago Packages to whatever is latest in this release!\n"
+echo -e "Running as " && whoami;
+composer update strawberryfield/strawberryfield strawberryfield/format_strawberryfield strawberryfield/webform_strawberryfield archipelago/archipelago_subtheme --no-scripts;
+(($? != 0)) && { printf '%s\n' "Updating strawberryfield packages via composer failed"; exit 1; }
+drush status bootstrap | grep -q Successful;
+(($? == 0)) && { drush cr; }
+echo -e "If you see no errors, you are up to date!"

--- a/scripts/archipelago/update.sh
+++ b/scripts/archipelago/update.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
-echo -e "Updating Archipelago Packages to whatever is latest in this release!\n"
-echo -e "Running as " && whoami;
+
+# Part of the Archipelago Commons Project
+# This should be run as: docker exec -ti esmero-php bash -c 'scripts/archipelago/update.sh'
+
+echo -ne "Updating Archipelago Packages to whatever is latest in this release!\n"
+echo -ne "Running as " && whoami;
 composer update strawberryfield/strawberryfield strawberryfield/format_strawberryfield strawberryfield/webform_strawberryfield archipelago/archipelago_subtheme --no-scripts;
 (($? != 0)) && { printf '%s\n' "Updating strawberryfield packages via composer failed"; exit 1; }
 drush status bootstrap | grep -q Successful;
 (($? == 0)) && { drush cr; }
-echo -e "If you see no errors, you are up to date!"
+echo -ne "Taking ownership of drupal modules for the www-data user, this can take a little while!" && chown -R www-data web/modules/* vendor/*;
+echo -e "If you see no errors, you are up to date! Done."


### PR DESCRIPTION
# What is new?

See #8 
For people running/testing archipelago during a release or in between, having a simple script to update all archipelago dependant packages at once seems like a good idea, so here there is a too basic bash script that does it

# How to test?

You have archipelago running and are super happy or confused. We just updated webform_strawberryfield to fix a bug. How do you apply that to your shiny new thing?

Run

`docker exec -ti esmero-php bash -c 'scripts/archipelago/update.sh'`
You should see this if all is already up to date
```SHELL
Updating Archipelago Packages to whatever is latest in this release!
Running as root
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Loading composer repositories with package information
Updating dependencies (including require-dev)                
Nothing to install or update
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Generating autoload files
 [success] Cache rebuild complete.
Taking ownership of drupal modules for the www-data user    
If you see no errors, you are up to date!
```
And if not something like
strawberryfield/format_strawberryfield (dev-8.x-1.0-beta1 d130e5c): Updating d130e5c4b7 from cache 

# Note
This will try to run `drush cr`; only if Drupal is actually installed. Edge case if people don't follow instructions and try run `update.sh` before installing Archipelago which funny enough will install every package, so Don't do it.)

@giancarlobi this is the missing piece to test the latest https://github.com/esmero/webform_strawberryfield/commit/5e20cc41f7ee6ee37a4b6269f2fc84768ec7fc54. Hope it works for you. 