### PR TITLE
ISSUE 11: Give nginx a larger buffer

### DIFF
--- a/nginxconfigford8/default.conf
+++ b/nginxconfigford8/default.conf
@@ -8,6 +8,9 @@ server {
     fastcgi_read_timeout 120s;
     fastcgi_pass_request_headers on;
 
+    fastcgi_buffers 16 16k; 
+    fastcgi_buffer_size 32k;
+    
     location = /favicon.ico {
         log_not_found off;
         access_log off;


### PR DESCRIPTION
# What is new?

See #11 

This is really just intended for people developing archipelago, but still good to have.

This small change gives Nginx a larger buffer so debug statements send to output don't end in a 502 error. 

# How to test?
Checkout this branch, restart your docker containers like this
```
docker-compose restart
```

Archipelago should be working as usual. 