### PR TITLE
ISSUE-19d: Fix Config Warning on Display Field Copy Module 1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -127,6 +127,9 @@
             },
             "drupal/devel": {
             "Fix BlockdataCollector for 3.x": "patches/devel-webprofiler-BlocksDataCollector-3106747-2-D8.patch"
+            },
+            "drupal/display_field_copy": {
+            "Fix missing schema 1.x": "patches/1.x-display_field_copy-missing-schema-3107615-2-D8.patch"
             }
         }
     }

--- a/config/sync/core.entity_view_display.node.digital_object.digital_object_with_pannellum_panorama.yml
+++ b/config/sync/core.entity_view_display.node.digital_object.digital_object_with_pannellum_panorama.yml
@@ -3,7 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
-    - core.entity_view_mode.node.digital_object_with_pannellum_panorama_
+    - core.entity_view_mode.node.digital_object_with_pannellum_panorama
     - field.field.node.digital_object.body
     - field.field.node.digital_object.field_descriptive_metadata
     - node.type.digital_object
@@ -66,10 +66,10 @@ third_party_settings:
             specs: 'https://iiif.io/api/presentation/3.0/'
             metadatadisplayentity_id: '3'
             metadatadisplayentity_uselabel: '1'
-id: node.digital_object.digital_object_with_pannellum_panorama_
+id: node.digital_object.digital_object_with_pannellum_panorama
 targetEntityType: node
 bundle: digital_object
-mode: digital_object_with_pannellum_panorama_
+mode: digital_object_with_pannellum_panorama
 content:
   body:
     label: hidden

--- a/config/sync/core.entity_view_mode.node.digital_object_with_pannellum_panorama.yml
+++ b/config/sync/core.entity_view_mode.node.digital_object_with_pannellum_panorama.yml
@@ -4,7 +4,7 @@ status: true
 dependencies:
   module:
     - node
-id: node.digital_object_with_pannellum_panorama_
-label: 'Digital Object with Pannellum Panorama '
+id: node.digital_object_with_pannellum_panorama
+label: 'Digital Object with Pannellum Panorama'
 targetEntityType: node
 cache: true

--- a/patches/1.x-display_field_copy-missing-schema-3107615-2-D8.patch
+++ b/patches/1.x-display_field_copy-missing-schema-3107615-2-D8.patch
@@ -1,0 +1,14 @@
+diff --git a/config/schema/display_field_copy.schema.yml b/config/schema/display_field_copy.schema.yml
+new file mode 100644
+index 0000000..2a87ecf
+--- /dev/null
++++ b/config/schema/display_field_copy.schema.yml
+@@ -0,0 +1,8 @@
++ds.field.properties.display_field_copy:
++  type: mapping
++  label: 'Display Suite copy field properties'
++  mapping:
++    field_id:
++      type: string
++      label: 'Field ID'
++


### PR DESCRIPTION
# What is new?
After upgrade to 8.8.1, configuration inspector became way more verbose about configs. Display Field Copy Module lacks a proper schema file, so this patch provides an 'in the meantime' fix until our reported https://www.drupal.org/project/display_field_copy/issues/3107615#comment-13429229 gets merged or reviewed.