### PR TITLE
ISSUE-19g: bump PHP upload size via nginx

### DIFF
--- a/nginxconfigford8/default.conf
+++ b/nginxconfigford8/default.conf
@@ -79,6 +79,7 @@ server {
         fastcgi_param HTTP_PROXY "";
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param PHP_VALUE "upload_max_filesize=512M \n post_max_size=512M";
         proxy_read_timeout 900s;
         fastcgi_intercept_errors on;
         fastcgi_pass esmero-php:9000;


### PR DESCRIPTION
# What is this, blackmagic?

One of he benefits of using nginx and fastcgi PHP (php-fpm) is that we can modify php.ini values without touching our php.ini or any of our containers. This sets max file Upload size to 512M for php 7.3.1 directly in our `nginx` container config file. Fast.

Just in case you wonder, `client_max_body_size 512M; in the `server` section was already set before.