### PR TITLE
ISSUE-33: Bump drupal/config_inspector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "drupal-composer/drupal-scaffold": "^2.2",
         "drupal/bamboo_twig": "5.x-dev",
         "drupal/bootstrap_barrio": "^4.22",
-        "drupal/config_inspector": "^1.0@beta",
+        "drupal/config_inspector": "dev-1.x",
         "drupal/config_installer": "^1.7",
         "drupal/config_update": "^1.6",
         "drupal/config_update_ui": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2f21bf1ea9f6c2789d536b7119a30a7a",
+    "content-hash": "148b58e6b9c3d74a82db063fcf635c8b",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -3094,17 +3094,11 @@
         },
         {
             "name": "drupal/config_inspector",
-            "version": "1.0.0",
+            "version": "dev-1.x",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/config_inspector.git",
-                "reference": "8.x-1.0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/config_inspector-8.x-1.0.zip",
-                "reference": "8.x-1.0",
-                "shasum": "dc92ceb8fd3e289f9e5c058692346e4b9ef3fa74"
+                "reference": "1e034975ae3244c7a3d30b1691046a9a7453f27c"
             },
             "require": {
                 "drupal/core": "^8 || ^9"
@@ -3115,11 +3109,11 @@
                     "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-1.0",
-                    "datestamp": "1569419586",
+                    "version": "8.x-1.0+4-dev",
+                    "datestamp": "1575554584",
                     "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
+                        "status": "not-covered",
+                        "message": "Dev releases are not covered by Drupal security advisories."
                     }
                 },
                 "drush": {
@@ -3160,7 +3154,8 @@
                 "source": "https://cgit.drupalcode.org/config_inspector",
                 "issues": "https://drupal.org/project/issues/config_inspector",
                 "irc": "irc://irc.freenode.org/drupal-contribute"
-            }
+            },
+            "time": "2019-12-05T13:58:42+00:00"
         },
         {
             "name": "drupal/config_installer",
@@ -13448,7 +13443,7 @@
     "stability-flags": {
         "archipelago/archipelago_subtheme": 20,
         "drupal/bamboo_twig": 20,
-        "drupal/config_inspector": 10,
+        "drupal/config_inspector": 20,
         "drupal/context": 10,
         "drupal/devel": 20,
         "drupal/display_field_copy": 20,


### PR DESCRIPTION
See #33 

# What changes?

`drupal/config_inspector`contributed module gets bumped from From `1.0@beta` to `dev-1.x `and we are setting the hash on current working version via `composer.lock` to ensure it sticks. Current deployed version of this module was failing to render its own Twig templates on Drupal 8.8.1

@marlo-longley detected this error. Merging as soon as i get this in!

