### PR TITLE
ISSUE-36: make Cantaloupe 4.1.5 the new standard / Beta2 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,9 @@
         },
         "enable-patching": true,
         "patches": {
+            "drupal/drupal": {
+            "Fix Drupal.ajax 8.8.x for bigpipe and CDN":"https://www.drupal.org/files/issues/2019-12-30/1988968-162.patch"
+            },
             "drupal/form_mode_manager": {
             "Fix Form Mode title": "https://www.drupal.org/files/issues/2019-12-10/form_mode_manager-bundle-label-in-title-3100112-2-D8.patch"
             },

--- a/composer.lock
+++ b/composer.lock
@@ -10370,12 +10370,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/esmero/strawberryfield.git",
-                "reference": "761ddf7e925592a60b98c6b1d05319bf0682f786"
+                "reference": "d3181d2d83e514d6abf5dfafbc65d64d532b1a09"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/esmero/strawberryfield/zipball/761ddf7e925592a60b98c6b1d05319bf0682f786",
-                "reference": "761ddf7e925592a60b98c6b1d05319bf0682f786",
+                "url": "https://api.github.com/repos/esmero/strawberryfield/zipball/d3181d2d83e514d6abf5dfafbc65d64d532b1a09",
+                "reference": "d3181d2d83e514d6abf5dfafbc65d64d532b1a09",
                 "shasum": ""
             },
             "require": {
@@ -10400,7 +10400,7 @@
             ],
             "description": "A strawberry field for Drupal 8",
             "homepage": "https://github.com/esmero/strawberryfield",
-            "time": "2020-02-07T16:04:33+00:00"
+            "time": "2020-02-15T00:21:13+00:00"
         },
         {
             "name": "strawberryfield/webform_strawberryfield",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "148b58e6b9c3d74a82db063fcf635c8b",
+    "content-hash": "3d13cc66dc6e3ce4eb1f22cad5bb0fab",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -76,12 +76,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/esmero/archipelago_subtheme.git",
-                "reference": "facd1e355cf16a5512945ed320615661ad0f0445"
+                "reference": "3f6951a65f56a23b79eb2215da6bc13f4de1dd47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/esmero/archipelago_subtheme/zipball/facd1e355cf16a5512945ed320615661ad0f0445",
-                "reference": "facd1e355cf16a5512945ed320615661ad0f0445",
+                "url": "https://api.github.com/repos/esmero/archipelago_subtheme/zipball/3f6951a65f56a23b79eb2215da6bc13f4de1dd47",
+                "reference": "3f6951a65f56a23b79eb2215da6bc13f4de1dd47",
                 "shasum": ""
             },
             "require": {
@@ -102,7 +102,7 @@
             ],
             "description": "Bare Bone Bootstrap4 to be further extended by nice people",
             "homepage": "https://github.com/esmero/archipelago_subtheme",
-            "time": "2019-09-04T18:17:48+00:00"
+            "time": "2020-02-13T22:11:08+00:00"
         },
         {
             "name": "asm89/stack-cors",
@@ -10332,12 +10332,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/esmero/format_strawberryfield.git",
-                "reference": "6d3fcfb48757a16980be470283a724462357b954"
+                "reference": "7535e15ce09f3b9c6d653b7f31738df512bd6dd9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/esmero/format_strawberryfield/zipball/6d3fcfb48757a16980be470283a724462357b954",
-                "reference": "6d3fcfb48757a16980be470283a724462357b954",
+                "url": "https://api.github.com/repos/esmero/format_strawberryfield/zipball/7535e15ce09f3b9c6d653b7f31738df512bd6dd9",
+                "reference": "7535e15ce09f3b9c6d653b7f31738df512bd6dd9",
                 "shasum": ""
             },
             "require": {
@@ -10362,7 +10362,7 @@
             ],
             "description": "Strawberryfield Mash/Smash/extractor/formatters for Drupal 8",
             "homepage": "https://github.com/esmero/format_strawberryfield",
-            "time": "2020-02-07T15:24:13+00:00"
+            "time": "2020-02-14T21:57:46+00:00"
         },
         {
             "name": "strawberryfield/strawberryfield",

--- a/docker-compose-nginx.yml
+++ b/docker-compose-nginx.yml
@@ -66,7 +66,7 @@ services:
       - ${PWD}/persistent/db:/var/lib/mysql:cached
   iiif:
     container_name: esmero-cantaloupe
-    image: "esmero/cantaloupe-s3:4.0.3"
+    image: "esmero/cantaloupe-s3:4.1.5"
     restart: always
     ports:
       - "8183:8182"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - ${PWD}/persistent/db:/var/lib/mysql:cached
   iiif:
     container_name: esmero-cantaloupe
-    image: "esmero/cantaloupe-s3:4.0.3"
+    image: "esmero/cantaloupe-s3:4.1.5"
     restart: always
     ports:
       - "8183:8182"

--- a/persistent/iiifconfig/cantaloupe.properties
+++ b/persistent/iiifconfig/cantaloupe.properties
@@ -53,6 +53,9 @@ slash_substitute =
 # response. Set to 0 for no maximum.
 max_pixels = 400000000
 
+# Maximum scale to allow (1.0 = full scale; 0 = no maximum).
+max_scale = 1.0
+
 # Errors will also be logged to the error log (if enabled).
 print_stack_trace_on_error_pages = true
 
@@ -76,11 +79,6 @@ delegate_script.cache.enabled = false
 ###########################################################################
 # ENDPOINTS
 ###########################################################################
-
-# !! Configures HTTP Basic authentication in all public endpoints.
-endpoint.public.auth.basic.enabled = false
-endpoint.public.auth.basic.username = myself
-endpoint.public.auth.basic.secret = mypassword
 
 # Enables the IIIF Image API 1.x endpoint, at /iiif/1.
 endpoint.iiif.1.enabled = false
@@ -129,6 +127,64 @@ source.static = S3Source
 source.delegate = false
 
 #----------------------------------------
+# FilesystemSource
+#----------------------------------------
+
+# How to look up files. Allowed values are `BasicLookupStrategy` and
+# `ScriptLookupStrategy`. ScriptLookupStrategy uses the delegate script for
+# dynamic lookups; see the user manual.
+FilesystemSource.lookup_strategy = BasicLookupStrategy
+
+# Server-side path that will be prefixed to the identifier in the URL.
+# Trailing slash is important!
+FilesystemSource.BasicLookupStrategy.path_prefix = /home/myself/images/
+
+# Server-side path or extension that will be suffixed to the identifier in
+# the URL.
+FilesystemSource.BasicLookupStrategy.path_suffix =
+
+#----------------------------------------
+# HttpSource
+#----------------------------------------
+
+# Trusts insecure certificates and cipher suites.
+HttpSource.allow_insecure = false
+
+# Request timeout in seconds.
+HttpSource.request_timeout =
+
+# Tells HttpSource how to look up resources. Allowed values are
+# `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
+# uses a delegate method for dynamic lookups; see the user manual.
+HttpSource.lookup_strategy = BasicLookupStrategy
+
+# URL that will be prefixed to the identifier in the request URL.
+# Trailing slash is important!
+HttpSource.BasicLookupStrategy.url_prefix = http://localhost/images/
+
+# Path, extension, query string, etc. that will be suffixed to the
+# identifier in the request URL.
+HttpSource.BasicLookupStrategy.url_suffix =
+
+# Enables access to resources that require HTTP Basic authentication.
+HttpSource.BasicLookupStrategy.auth.basic.username =
+HttpSource.BasicLookupStrategy.auth.basic.secret =
+
+# Read data in chunks when it may be more efficient. (This also may end up
+# being less efficient, depending on many variables; see the user manual.)
+HttpSource.chunking.enabled = true
+
+# Chunk size.
+HttpSource.chunking.chunk_size = 512K
+
+# The per-request chunk cache caches downloaded chunks in memory during
+# a request, and clears them when the request is complete.
+HttpSource.chunking.cache.enabled = true
+
+# Max per-request chunk cache size.
+HttpSource.chunking.cache.max_size = 5M
+
+#----------------------------------------
 # S3Source
 #----------------------------------------
 
@@ -145,10 +201,6 @@ S3Source.endpoint = http://esmero-minio:9000
 S3Source.access_key_id = minio
 S3Source.secret_key = minio123
 
-# !! Maximum number of concurrent HTTP connections to AWS. Leave blank to
-# use the default.
-S3Source.max_connections =
-
 # Tells S3Source how to look up objects. Allowed values are
 # `BasicLookupStrategy` and `ScriptLookupStrategy`. ScriptLookupStrategy
 # uses a delegate method for dynamic lookups; see the user manual.
@@ -164,6 +216,19 @@ S3Source.BasicLookupStrategy.path_prefix = /
 # Path or extension that will be suffixed to the identifier in the URL.
 S3Source.BasicLookupStrategy.path_suffix =
 
+# Read data in chunks when it may be more efficient. (This also may end up
+# being less efficient, depending on many variables; see the user manual.)
+S3Source.chunking.enabled = true
+
+# Chunk size.
+S3Source.chunking.chunk_size = 512K
+
+# The per-request chunk cache caches downloaded chunks in memory during
+# a request, and clears them when the request is complete.
+S3Source.chunking.cache.enabled = true
+
+# Max per-request chunk cache size.
+S3Source.chunking.cache.max_size = 5M
 
 ###########################################################################
 # PROCESSORS
@@ -173,29 +238,37 @@ S3Source.BasicLookupStrategy.path_suffix =
 # Processor Selection
 #----------------------------------------
 
+# * If set to `AutomaticSelectionStrategy`, a "best" available processor
+#   will be selected per-request based on formats and installed
+#   dependencies.
+# * If set to `ManualSelectionStrategy`, a processor will be chosen based
+#   on the rest of the keys in this section.
+processor.selection_strategy = ManualSelectionStrategy
+
+
 # Image processors to use for various source formats. Available values are
 # `Java2dProcessor`, `GraphicsMagickProcessor`, `ImageMagickProcessor`,
 # `KakaduDemoProcessor`, `KakaduNativeProcessor`, `OpenJpegProcessor`,
 # `JaiProcessor`, `PdfBoxProcessor`, and `FfmpegProcessor`.
 
 # These extension-specific definitions are optional.
-processor.avi = FfmpegProcessor
-processor.bmp =
-processor.dcm = GraphicsMagickProcessor
-processor.flv = FfmpegProcessor
-processor.gif =
-processor.jp2 = OpenJpegProcessor
-processor.jpg = Java2dProcessor
-processor.mov = FfmpegProcessor
-processor.mp4 = FfmpegProcessor
-processor.mpg = FfmpegProcessor
-processor.pdf = GraphicsMagickProcessor
-processor.png = Java2dProcessor
-processor.tif = Java2dProcessor
-processor.webm = FfmpegProcessor
+processor.ManualSelectionStrategy.avi = FfmpegProcessor
+processor.ManualSelectionStrategy.bmp =
+processor.ManualSelectionStrategy.dcm = GraphicsMagickProcessor
+processor.ManualSelectionStrategy.flv = FfmpegProcessor
+processor.ManualSelectionStrategy.gif =
+processor.ManualSelectionStrategy.jp2 = OpenJpegProcessor
+processor.ManualSelectionStrategy.jpg = TurboJpegProcessor
+processor.ManualSelectionStrategy.mov = FfmpegProcessor
+processor.ManualSelectionStrategy.mp4 = FfmpegProcessor
+processor.ManualSelectionStrategy.mpg = FfmpegProcessor
+processor.ManualSelectionStrategy.pdf = PdfBoxProcessor
+processor.ManualSelectionStrategy.png = Java2dProcessor
+processor.ManualSelectionStrategy.tif = Java2dProcessor
+processor.ManualSelectionStrategy.webm = FfmpegProcessor
 
 # Fall back to this processor for any formats not assigned above.
-processor.fallback = Java2dProcessor
+processor.ManualSelectionStrategy.fallback = Java2dProcessor
 
 #----------------------------------------
 # Global Processor Configuration
@@ -219,10 +292,6 @@ processor.fallback_retrieval_strategy = CacheStrategy
 
 # Resolution of vector rasterization (of e.g. PDFs) at a scale of 1.
 processor.dpi = 150
-
-# Expands contrast to utilize available dynamic range. This usually requires
-# the whole source image to be read into memory, so it can be inefficient.
-processor.normalize = false
 
 # Color of the background when an image is rotated or alpha-flattened, for
 # output formats that don't support transparency.
@@ -627,3 +696,4 @@ log.access.SyslogAppender.host =
 log.access.SyslogAppender.port = 514
 log.access.SyslogAppender.facility = LOCAL0
 processor.webp =
+processor.ManualSelectionStrategy.webp=

--- a/persistent/iiifconfig/cantaloupe.properties
+++ b/persistent/iiifconfig/cantaloupe.properties
@@ -695,5 +695,3 @@ log.access.SyslogAppender.enabled = false
 log.access.SyslogAppender.host =
 log.access.SyslogAppender.port = 514
 log.access.SyslogAppender.facility = LOCAL0
-processor.webp =
-processor.ManualSelectionStrategy.webp=


### PR DESCRIPTION
See #36 

# What is new?

Let's bump and update cantaloupe to 4.1.5 for this release! Recompiled the thing and update docker files. See, here https://github.com/esmero/archipelago-docker-images/commit/2953006e5d8feca484e7ef65e852cacdd8d3a7b6. and pushed a new tag to docker hub: `esmero/cantaloupe-s3:4.1.5` Includes Java 13! Well, we are ahead of times =) and latest as of december 2019 graphics-magic. This also updates the settings for cantaloupe and changes some processors to match the new reality. Tested locally and works fine. Actually, not sure why, but images are WAY sharper... or my eyes slower? We may never know...

I used the opportunity (never miss a pull to do something extra) to add a Core Patch that is supposed to fix an issue with Ajax not loading, on time, or not at all, Drupal Libraries (JS, CSS, etc), specially from CDN, when using something like a Modal Dialog from JQuery or the Drupal wrapper. This is needed to make the interaction of popups in `panoramas`, and in the future Web`annotations` that are actually fully rendered other ADOs with their own Viewers, easier. Less manually attaching JS that are already defined and work standalone on each ADOs canonical page.

Happy Valentines you people! ❤️ 🌷 🤖 