### PR TITLE
ISSUE-49: Fix wrong TIF configuration (beta2)

### DIFF
--- a/persistent/iiifconfig/cantaloupe.properties
+++ b/persistent/iiifconfig/cantaloupe.properties
@@ -253,10 +253,10 @@ processor.selection_strategy = ManualSelectionStrategy
 
 # These extension-specific definitions are optional.
 processor.ManualSelectionStrategy.avi = FfmpegProcessor
-processor.ManualSelectionStrategy.bmp =
+processor.ManualSelectionStrategy.bmp = Java2dProcessor
 processor.ManualSelectionStrategy.dcm = GraphicsMagickProcessor
 processor.ManualSelectionStrategy.flv = FfmpegProcessor
-processor.ManualSelectionStrategy.gif =
+processor.ManualSelectionStrategy.gif = Java2dProcessor
 processor.ManualSelectionStrategy.jp2 = OpenJpegProcessor
 processor.ManualSelectionStrategy.jpg = TurboJpegProcessor
 processor.ManualSelectionStrategy.mov = FfmpegProcessor
@@ -264,7 +264,9 @@ processor.ManualSelectionStrategy.mp4 = FfmpegProcessor
 processor.ManualSelectionStrategy.mpg = FfmpegProcessor
 processor.ManualSelectionStrategy.pdf = PdfBoxProcessor
 processor.ManualSelectionStrategy.png = Java2dProcessor
-processor.ManualSelectionStrategy.tif = Java2dProcessor
+processor.ManualSelectionStrategy.tif = GraphicsMagickProcessor
+processor.ManualSelectionStrategy.tif = GraphicsMagickProcessor
+
 processor.ManualSelectionStrategy.webm = FfmpegProcessor
 
 # Fall back to this processor for any formats not assigned above.


### PR DESCRIPTION
# What is this?
This was found by Tom from CSHL. Java2D seems not be able to process TIFF files in the latest version (which we updated to on Beta2) if the source is stored in S3. This pull also enables GIF via IIIF. This is a config/bug-fix. 

Also odd. Since `processor.selection_strategy = ManualSelectionStrategy` if even converted to automatic would fail.. sad. But, could also be an issue with the strategy, maybe JAVA2D requires the download and can not stream?

This fixes beta2. Will do the same for beta3 too