### PR TITLE
ISSUE-52: Update Audio Player default dimensions

### DIFF
--- a/config/sync/core.entity_view_display.node.digital_object.digital_object_with_a_v_player.yml
+++ b/config/sync/core.entity_view_display.node.digital_object.digital_object_with_a_v_player.yml
@@ -43,8 +43,8 @@ third_party_settings:
           formatter:
             json_key_source: 'as:audio'
             number_media: 1
-            max_width: '320'
-            max_height: '240'
+            max_width: '720'
+            max_height: '50'
       'display_field_copy:node-formatted_metadata':
         plugin_id: 'display_field_copy:node-formatted_metadata'
         weight: 3


### PR DESCRIPTION
See #52 (Transferred from Formatter since this is a setting)

This updates the deployed width and height of the Audio player 

core.entity_view_display.node.digital_object.digital_object_with_a_v_player.yml

This needs to be tested with transcripts enabled, but maybe we can simply add in the code itself the offset (extra height?) if transcripts are provided instead of changing this default.

@mitchellkeaney 