### PR TITLE
ISSUE-114: make Xdebug 3 work on archipelago-deployment RC3 

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,10 +28,14 @@ services:
   php-debug:
     container_name: esmero-php-debug
     restart: always
-    image: esmero/php-7.3-fpm:development
+    image: esmero/php-7.4-fpm:1.0.0-dev-multiarch
+    environment:
+      - XDEBUG_SESSION_START="archipelago"
     tty: true
     networks:
       - host-net
       - esmero-net
     volumes:
       - ${PWD}:/var/www/html:cached
+      - ${PWD}/xdebug/xdebug.ini:/usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+

--- a/xdebug/xdebug.ini
+++ b/xdebug/xdebug.ini
@@ -1,0 +1,6 @@
+zend_extension=xdebug
+
+[xdebug]
+xdebug.mode=develop,debug
+xdebug.client_host=host.docker.internal
+xdebug.start_with_request=yes

--- a/xdebug/xdebug.ini
+++ b/xdebug/xdebug.ini
@@ -2,5 +2,8 @@ zend_extension=xdebug
 
 [xdebug]
 xdebug.mode=develop,debug
+; If your host system is Linux, host.docker.internal may not be available.
 xdebug.client_host=host.docker.internal
+; On linux comment xdebug.client_host=host.docker.internal and uncomment the following next line
+;xdebug.discover_client_host=1
 xdebug.start_with_request=yes


### PR DESCRIPTION
# What is this?

- New PHP 7.4 Xdebug enabled docker container with XDEBUG 3
- Modified docker-compose.dev.yml complementary file triggered by an XDEBUG_SESSION = archipelago cookie
- an additional xdebug.ini to get started


New things:

- Listen to default port 9003

Does it work?

Yes!
