### PR TITLE
Update docker-compose files to work with the new MinIO console

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9918,16 +9918,16 @@
         },
         {
             "name": "pear/archive_tar",
-            "version": "1.4.13",
+            "version": "1.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Archive_Tar.git",
-                "reference": "2b87b41178cc6d4ad3cba678a46a1cae49786011"
+                "reference": "4d761c5334c790e45ef3245f0864b8955c562caa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/2b87b41178cc6d4ad3cba678a46a1cae49786011",
-                "reference": "2b87b41178cc6d4ad3cba678a46a1cae49786011",
+                "url": "https://api.github.com/repos/pear/Archive_Tar/zipball/4d761c5334c790e45ef3245f0864b8955c562caa",
+                "reference": "4d761c5334c790e45ef3245f0864b8955c562caa",
                 "shasum": ""
             },
             "require": {
@@ -9994,7 +9994,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-02-16T10:50:50+00:00"
+            "time": "2021-07-20T13:53:39+00:00"
         },
         {
             "name": "pear/console_getopt",
@@ -17418,5 +17418,5 @@
         "php": ">=7.3"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/docker-compose-legacy.yml
+++ b/docker-compose-legacy.yml
@@ -85,13 +85,14 @@ services:
          - ${PWD}/persistent/miniodata:/data:cached
     ports:
          - "9000:9000"
+         - "9001:9001"
     networks:
       - host-net
       - esmero-net
     environment:
          MINIO_ACCESS_KEY: minio
          MINIO_SECRET_KEY: minio123
-    command: server /data
+    command: server /data --console-address ":9001"
 networks:
   host-net:
     driver: bridge

--- a/docker-compose-linux.yml
+++ b/docker-compose-linux.yml
@@ -97,13 +97,14 @@ services:
          - ${PWD}/persistent/miniodata:/data:cached
     ports:
          - "9000:9000"
+         - "9001:9001"
     networks:
       - host-net
       - esmero-net
     environment:
          MINIO_ACCESS_KEY: minio
          MINIO_SECRET_KEY: minio123
-    command: server /data
+    command: server /data --console-address ":9001"
 networks:
   host-net:
     driver: bridge

--- a/docker-compose-osx.yml
+++ b/docker-compose-osx.yml
@@ -97,13 +97,14 @@ services:
          - ${PWD}/persistent/miniodata:/data:cached
     ports:
          - "9000:9000"
+         - "9001:9001"
     networks:
       - host-net
       - esmero-net
     environment:
          MINIO_ACCESS_KEY: minio
          MINIO_SECRET_KEY: minio123
-    command: server /data
+    command: server /data --console-address ":9001"
 networks:
   host-net:
     driver: bridge


### PR DESCRIPTION
Open/bind port 9001 in Docker, and update the MinIO start command to use this port for the console interface.

Resolves https://github.com/esmero/archipelago-deployment/issues/118

The `minio/minio:latest` docker image includes the console inside the same container as the server, so this PR will also resolve https://github.com/esmero/archipelago-deployment/issues/108 unless it is desired to run a standalone instance of the MinIO Console in a separate container.