### PR TITLE
ISSUE-118: Fix MINIO on RC2 to RELEASE.2021-06-07T21-40-51Z

### DIFF
--- a/docker-compose-legacy.yml
+++ b/docker-compose-legacy.yml
@@ -80,7 +80,7 @@ services:
   minio:
     container_name: esmero-minio
     restart: always
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2021-06-07T21-40-51Z
     volumes:
          - ${PWD}/persistent/miniodata:/data:cached
     ports:

--- a/docker-compose-linux.yml
+++ b/docker-compose-linux.yml
@@ -92,7 +92,7 @@ services:
   minio:
     container_name: esmero-minio
     restart: always
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2021-06-07T21-40-51Z
     volumes:
          - ${PWD}/persistent/miniodata:/data:cached
     ports:

--- a/docker-compose-osx.yml
+++ b/docker-compose-osx.yml
@@ -92,7 +92,7 @@ services:
   minio:
     container_name: esmero-minio
     restart: always
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2021-06-07T21-40-51Z
     volumes:
          - ${PWD}/persistent/miniodata:/data:cached
     ports:


### PR DESCRIPTION
# What?

See #118 and #119  
This fixes RC2 on the last Stable MINIO version that still had Minio Browser and RC3 now will include the New Console (Thanks to @mbennett-uoe!)

We will need to update for RC3 the Documentation too (not yet, more changes to come)
