### PR TITLE
remind default pw

### DIFF
--- a/docs/democontent.md
+++ b/docs/democontent.md
@@ -19,7 +19,7 @@ You can learn and test. Then delete and move over.
 
 - You installed it either via the Step by Step [deployment on OSX](osx.md), the one for [Ubuntu](ubuntu.md) or using your secret powers directly on a VM/Metal/Cloud/EC2 or even a raspberryPI.
 - You followed the guides without being too creative which means you have an `jsonapi` drupal user and an `admin` one and you can login and out of your server.
-- You remember your `admin`user
+- You remember your `admin` user. (If you followed one of the deployment guides, password will be `archipelago`)
 
 ## Step 1: (only step)
 


### PR DESCRIPTION
unless i'm missing something (possible!) you have to sidescroll through the following command 
```
docker exec -ti -u www-data esmero-php bash -c "cd web;../vendor/bin/drush -y si --verbose --existing-config --db-url=mysql://root:esmerodb@esmero-db/drupal9 --account-name=admin --account-pass=archipelago -r=/var/www/html/web --sites-subdir=default --notify=false;drush cr;chown -R www-data:www-data sites;"
```
in the deploy guides to know the default `admin` pw is `archipelago`. 

this pr just surfaces that pw on the demo content doc.