### PR TITLE
Born-Digital:1.0.0-RC3 -- update jquery ui slider patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -179,7 +179,7 @@
         "enable-patching": true,
         "patches": {
             "drupal/facets": {
-                "Fix deprecated JQUERY UI Slider": "https://www.drupal.org/files/issues/2021-11-12/issue-3153622-nouislider_25.patch" 
+                "Fix deprecated JQUERY UI Slider": "https://www.drupal.org/files/issues/2022-03-07/issue-315622-nouislider_25_0.patch"
             }
         }
     }


### PR DESCRIPTION
The jquery ui slider patch was re-rolled. See https://www.drupal.org/project/facets/issues/3153622#comment-14436141