### PR TITLE
ISSUE-162: Update configs for Data CreativeWorks Series Drupal view

### DIFF
--- a/config/sync/core.entity_view_display.node.digital_object.digital_object_with_thumbnail_for_grid.yml
+++ b/config/sync/core.entity_view_display.node.digital_object.digital_object_with_thumbnail_for_grid.yml
@@ -28,7 +28,6 @@ third_party_settings:
           ds_content: div
     regions:
       ds_content:
-        - node_changed_date
         - node_title
         - field_descriptive_metadata
         - search_api_excerpt

--- a/config/sync/core.entity_view_display.node.digital_object_collection.digital_object_with_thumbnail_for_grid.yml
+++ b/config/sync/core.entity_view_display.node.digital_object_collection.digital_object_with_thumbnail_for_grid.yml
@@ -24,7 +24,6 @@ third_party_settings:
           ds_content: div
     regions:
       ds_content:
-        - node_changed_date
         - node_title
         - field_descriptive_metadata
         - search_api_excerpt

--- a/config/sync/views.view.creative_work_series_children.yml
+++ b/config/sync/views.view.creative_work_series_children.yml
@@ -203,17 +203,17 @@ display:
           reduce_duplicates: false
           plugin_id: search_api_options
       sorts:
-        changed:
-          id: changed
+        sequence_id_1:
+          id: sequence_id_1
           table: search_api_index_default_solr_index
-          field: changed
+          field: sequence_id_1
           relationship: none
           group_type: group
           admin_label: ''
           order: ASC
-          exposed: true
+          exposed: false
           expose:
-            label: Changed
+            label: ''
           plugin_id: search_api
         title_string:
           id: title_string

--- a/config/sync/views.view.creative_work_series_children.yml
+++ b/config/sync/views.view.creative_work_series_children.yml
@@ -215,6 +215,18 @@ display:
           expose:
             label: ''
           plugin_id: search_api
+        changed:
+          id: changed
+          table: search_api_index_default_solr_index
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
         title_string:
           id: title_string
           table: search_api_index_default_solr_index

--- a/config/sync/views.view.data_creativeworks_series.yml
+++ b/config/sync/views.view.data_creativeworks_series.yml
@@ -299,6 +299,18 @@ display:
           expose:
             label: ''
           plugin_id: search_api
+        changed:
+          id: changed 
+          table: search_api_index_default_solr_index
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          order: ASC
+          exposed: false
+          expose:
+            label: ''
+          plugin_id: search_api
         title_string:
           id: title_string
           table: search_api_index_default_solr_index


### PR DESCRIPTION
Resolves addendum to #162 , i.e.

- for the Creative Work Series Children View Sort Criteria, adding the sequence_id and removing the Changed (Exposed)
- for the Digital Object and Digital Object Collection Display modes for "Digital Object with Thumbnail for Grid", disabling Last Modified