### PR TITLE
Update to esmero/php-8.0.28-fpm:1.1.0-multiarch

### DIFF
--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -25,7 +25,7 @@ services:
   php:
     container_name: esmero-php
     restart: always
-    image: "esmero/php-8.0-fpm:1.1.0-multiarch"
+    image: "esmero/php-8.0.28-fpm:1.1.0-multiarch"
     tty: true
     networks:
       - host-net

--- a/docker-compose-linux.yml
+++ b/docker-compose-linux.yml
@@ -25,7 +25,7 @@ services:
   php:
     container_name: esmero-php
     restart: always
-    image: "esmero/php-8.0-fpm:1.1.0-multiarch"
+    image: "esmero/php-8.0.28-fpm:1.1.0-multiarch"
     tty: true
     networks:
       - host-net

--- a/docker-compose-osx.yml
+++ b/docker-compose-osx.yml
@@ -25,7 +25,7 @@ services:
   php:
     container_name: esmero-php
     restart: always
-    image: "esmero/php-8.0-fpm:1.1.0-multiarch"
+    image: "esmero/php-8.0.28-fpm:1.1.0-multiarch"
     tty: true
     networks:
       - host-net

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -28,7 +28,7 @@ services:
   php-debug:
     container_name: esmero-php-debug
     restart: always
-    image: esmero/php-8.0-fpm:1.1.0-dev-multiarch
+    image: esmero/php-8.0.28-fpm:1.1.0-dev-multiarch
     environment:
       - XDEBUG_SESSION_START="archipelago"
     tty: true


### PR DESCRIPTION
This updates the default php container to a security fix release. We don't have a dev equivalent right @aksm ?